### PR TITLE
feat: Replace calendar with meetup group widget

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -85,13 +85,8 @@ const socialCount = SOCIALS.filter(social => social.active).length;
 
     <section id="events">
       <h2 class="mb-8 text-center">Upcoming Events</h2>
-      <div class="calendar-container">
-        <iframe
-          src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%230535D1&showTz=0&showPrint=0&showTitle=0&showNav=0&showTabs=0&src=MzIwYjg0ODM3MWJjMDUyYjg5OWRhNTYyZTJmYTU4YjIxZjY3MDJlM2NkYWU3YWY0OGI4YjhkNWQ3NWMzYzA4YkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%234285F4"
-          width="800"
-          height="600"
-        ></iframe>
-      </div>
+        <p class="mb-8 text-center">See and sign up for our upcoming events on our Meetup Group!</p>
+        <div class="iframely-embed"><div class="iframely-responsive" style="height: 140px; padding-bottom: 0;"><a href="https://www.meetup.com/women-devs-sg/" data-iframely-url="//iframely.net/uC1jh2e"></a></div></div><script async src="//iframely.net/embed.js"></script>
     </section>
     {
       recentPosts.length > 0 && (


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

This PR replaces the currently empty google events calendar in our index page with a Meetup widget as an interim measure while the Meetup API key is still not available for a more complex GraphQL implementation. This interim measure will allow visitors to the site to be redirected to our Meetup site to sign up for our events.

| Screenshot |
| -------------- |
| ![image](https://github.com/user-attachments/assets/1c412d4e-b9c8-4b30-abc9-847583a0991f)|

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue
Temporarily resolves #4 . Do not close the issue yet.
<!-- If this PR is related to an existing issue, link to it here. -->
