### PR TITLE
feat: hide placeholder example member

### DIFF
--- a/src/content/members/member.md
+++ b/src/content/members/member.md
@@ -1,3 +1,4 @@
+<!-- This is a sample file to guide new members on how to add themselves to the community page. -->
 ---
 name: "Example Member"
 bio: "This is my bio."

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -15,7 +15,7 @@ import { getCollection } from "astro:content";
 const members = await getCollection("members");
 // Separate core members and regular members
 const coreMembers = members.filter(member => member.data.core).sort((a, b) => (a.data.rank ?? Infinity) - (b.data.rank ?? Infinity));
-const regularMembers = members.filter(member => !member.data.core);
+const regularMembers = members.filter(member => !member.data.core && !(member.id === 'member.md'));
 ---
 
 <Layout title={`Members | ${SITE.title}`}>


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

Added functionality to hide the placeholder example member file `member.md` from being rendered on the members page while keeping it available as a template for new contributors. The example file now includes clear comments indicating its purpose as a reference guide and is filtered out from the member listings.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->
- [x] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This change ensures that the example member file serves its intended purpose as a template without cluttering the actual members page. The filter condition uses the member id to exclude the specific example file while maintaining all other functionality.

<img width="749" height="404" alt="image" src="https://github.com/user-attachments/assets/d1138216-bf96-45a3-9ae2-4f15d026a0fb" />


## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #20<!-- Issue number, if applicable -->
