### PR TITLE
fix: website link

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -161,7 +161,7 @@ export const SOCIALS: SocialObjects = [
     name: "Website",
     href: "https://github.com/satnaing/astro-paper",
     linkTitle: `See my portfolio on ${SITE.title}`,
-    active: true,
+    active: false,
   },
   {
     name: "Figma",


### PR DESCRIPTION
## Description

A website icon appeared on live website, redirecting to an unrelated site. Removed the icon and link from appearing.

<img width="1182" height="630" alt="image" src="https://github.com/user-attachments/assets/8378793c-d5ed-4cd3-9eba-3dc4b32ca5fa" />

