### PR TITLE
Fix: add website field in profiles

### DIFF
--- a/src/content/members/aishwarya.md
+++ b/src/content/members/aishwarya.md
@@ -3,11 +3,12 @@ name: "Aishwarya Elango"
 bio: "Developer Relations Manager @ Women Devs SG"
 core: true
 socials:
+  - name: "Website"
+    href: "https://aishbuild273.hashnode.dev/"
   - name: "LinkedIn"
     href: "https://www.linkedin.com/in/aishwarya-elango/"
   - name: "Github"
     href: "https://github.com/grymoon5"
-url: https://aishbuild273.hashnode.dev/
 badges:
  - leader
 rank: 5

--- a/src/content/members/anarane.md
+++ b/src/content/members/anarane.md
@@ -3,9 +3,10 @@ name: "Anarane Tung"
 bio: "Software Engineer with backend and full-stack experience. I’m passionate about supporting Women in Tech and fostering Diversity and Inclusion. <3"
 core: false
 socials:
+  - name: "Website"
+    href: "https://anarane.com"
   - name: "LinkedIn"
     href: "https://www.linkedin.com/in/anarane/"
   - name: "Github"
     href: "https://github.com/anaranetung"
-url: https://anarane.com
 ---

--- a/src/content/members/natasha.md
+++ b/src/content/members/natasha.md
@@ -3,6 +3,8 @@ name: "Natasha Ann"
 bio: "Partnerships Lead @ Women Devs SG"
 core: true
 socials:
+  - name: "Website"
+    href: "https://natashaannn.com/"
   - name: "LinkedIn"
     href: "https://www.linkedin.com/in/natashaannn"
   - name: "Instagram"
@@ -11,7 +13,6 @@ socials:
     href: "https://github.com/natashaannn"
   - name: "TikTok"
     href: "https://www.tiktok.com/@natashaannn?lang=en:"
-url: https://natashaannn.com/
 badges:
  - leader
 rank: 4

--- a/src/content/members/pradheepa.md
+++ b/src/content/members/pradheepa.md
@@ -3,13 +3,14 @@ name: "Pradheepa Pullanieswaran"
 bio: "Software Track Leader @ Women Devs SG"
 core: true
 socials:
+  - name: "Website"
+    href: "https://www.pradheepa.com"
   - name: "LinkedIn"
     href: "https://www.linkedin.com/in/pradheepa/"
   - name: "Twitter"
     href: "https://twitter.com/pradheepa"
   - name: "Github"
     href: "https://github.com/pradheepap"
-url: https://www.pradheepa.com
 badges: 
   - leader
 ---

--- a/src/content/members/victoria.md
+++ b/src/content/members/victoria.md
@@ -3,13 +3,14 @@ name: "Victoria Lo"
 bio: "Director @ Women Devs SG"
 core: true
 socials:
+  - name: "Website"
+    href: "https://lo-victoria.com"
   - name: "LinkedIn"
     href: "https://www.linkedin.com/in/victoria2666/"
   - name: "Twitter"
     href: "https://twitter.com/lo_victoria2666"
   - name: "Github"
     href: "https://github.com/victoria-lo"
-url: https://lo-victoria.com
 badges: 
   - director
 rank: 3


### PR DESCRIPTION
## Description

This pull request updates the member profile files to improve how personal websites are displayed in the social links section. Previously, each member's website was included as a top-level `url` field; this has been removed and replaced with a "Website" entry in the `socials` list for each affected member. This change ensures consistency in how social links are presented across all member profiles.

Added a "Website" entry to the `socials` array for the following member profiles and removed the redundant top-level `url` field:
  - `aishwarya.md`
  - `anarane.md`
  - `natasha.md` 
  - `pradheepa.md`
  - `victoria.md`
  
  
<img width="1126" height="669" alt="image" src="https://github.com/user-attachments/assets/8149687b-6173-474c-aadf-8feb7afdef8a" />


## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue

Closes: #48 #49
