### PR TITLE
Fix: add role and company to Testimonials

### DIFF
--- a/src/components/Testimonials.astro
+++ b/src/components/Testimonials.astro
@@ -64,12 +64,16 @@ async function fetchFromSheet(id: string, name: string): Promise<Item[]> {
     const nameIdx = header.findIndex((h) => h.toLowerCase() === "name");
     const quoteIdx = header.findIndex((h) => h.toLowerCase() === "quote");
     const imageIdx = header.findIndex((h) => h.toLowerCase() === "imageurl");
+    const roleIdx = header.findIndex((h) => h.toLowerCase() === "role");
+    const companyIdx = header.findIndex((h) => h.toLowerCase() === "company");
     const out: Item[] = [];
     for (const r of dataRows) {
       const name = nameIdx >= 0 ? r[nameIdx]?.trim() : "";
       const quote = quoteIdx >= 0 ? r[quoteIdx]?.trim() : "";
       const imageUrl = imageIdx >= 0 ? r[imageIdx]?.trim() : undefined;
-      if (name && quote) out.push({ name, quote, imageUrl });
+      const role = roleIdx >= 0 ? r[roleIdx]?.trim() : undefined;
+      const company = companyIdx >= 0 ? r[companyIdx]?.trim() : undefined;
+      if (name && quote) out.push({ name, quote, imageUrl, role, company });
     }
     return out;
   } catch {


### PR DESCRIPTION
## Description

I overlooked `role` and `company` was left out of the `fetchFromSheet` function in PR #89 

## Types of changes

<!-- What types of changes does your code introduce to Women Dev SG's website? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [X] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments
Now role and company will probably be displayed

<img width="1226" height="543" alt="image" src="https://github.com/user-attachments/assets/a3f267d9-39c5-4394-8926-fd6f7eb073d6" />

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #<!-- Issue number, if applicable -->